### PR TITLE
Remove unused virtual clear power off pin for klipper 0.13

### DIFF
--- a/printer_configs/macros.cfg
+++ b/printer_configs/macros.cfg
@@ -422,12 +422,6 @@ gcode:
 variable_trigger_allowed: False
 gcode:
     {% if trigger_allowed %}
-        # Reset button state, otherwise only one trigger can occur
-        SET_PIN PIN=_clear_power_off VALUE=1
-        # There is a deboucing circuit which needs some delay
-        G4 P500
-        # Disable pin again otherwise on reset the button will be triggered 1-3 times
-        SET_PIN PIN=_clear_power_off VALUE=0
         RESPOND TYPE=error MSG="Shutdown triggered by button"
         SHUTDOWN
     {% endif %}

--- a/printer_configs/printer.base.cfg
+++ b/printer_configs/printer.base.cfg
@@ -150,11 +150,6 @@ pin: PC14
 value: 1
 shutdown_value: 1
 
-[output_pin _clear_power_off]
-pin: PG1
-value: 0
-shutdown_value: 0 
-
 [adxl345]
 cs_pin: eboard:PA4
 spi_speed: 1000000


### PR DESCRIPTION
There is a virtual latching mechanism for the power button inside the stock MCU firmware which always returns the button state as PRESSED until it gets a signal from virtual PG1 pin.
This has been implemented for stock screen to not miss any button presses so it can be omitted for non stock screen usage with klipper 0.13 MCU firmware.